### PR TITLE
Support spaces in arguments of start, stop and socket commands.

### DIFF
--- a/arg_test.go
+++ b/arg_test.go
@@ -1,13 +1,29 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func TestArgString(t *testing.T) {
 	cmdline := "-r /bin/sleep 10 -r /bin/echo -- \\-r"
-	if x := String(Args(strings.Fields(cmdline))); x != cmdline {
+	commands, flags := Args(strings.Fields(cmdline))
+	if x := strings.Join(String(commands), " "); x != cmdline {
 		t.Fatalf("expected '%s', got '%s'", cmdline, x)
+	}
+	if len(flags) != 0 {
+		t.Fatalf("expected 0 flags, got %q", flags)
+	}
+}
+
+func TestArgStringSpaces(t *testing.T) {
+	cmdline := []string{"-r", "/bin/bash", "-c", "/bin/sleep 10"}
+	commands, flags := Args(cmdline)
+	if x := String(commands); !reflect.DeepEqual(x, cmdline) {
+		t.Fatalf("expected %q, got %q", cmdline, x)
+	}
+	if len(flags) != 0 {
+		t.Fatalf("expected 0 flags, got %q", flags)
 	}
 }

--- a/unix.go
+++ b/unix.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net"
 	"os/exec"
-	"strings"
 )
 
 const (
@@ -12,17 +11,15 @@ const (
 )
 
 func startCommand(c net.Conn) {
-	buf := make([]byte, socketMaxLen)
-	n, err := c.Read(buf)
-
 	defer c.Close()
+
+	cmdargs, err := ReadArgs(c)
 	if err != nil {
 		lg.Printf("socket: error reading data: %s", err)
 		return
 	}
 
-	cmdargs := strings.Fields(string(buf[0:n]))
-	commands := Args(cmdargs)
+	commands, _ := Args(cmdargs)
 	run(commands, true)
 }
 
@@ -50,10 +47,6 @@ func write(sock string, cmds []*exec.Cmd) error {
 	if err != nil {
 		return err
 	}
-	str := String(cmds)
-	_, err = c.Write([]byte(str))
-	if err != nil {
-		return err
-	}
-	return nil
+	defer c.Close()
+	return WriteArgs(c, String(cmds))
 }


### PR DESCRIPTION
Serialize/deserialize start, stop and socket commands using space-separated csv formatting to preserve splitting. This allows whitespace inside arguments: where previously `dinit -submit -r /bin/bash -c "/bin/sleep 10"` would fail because the command would be run as `/bin/bash -c /bin/sleep 10` (so `10` was not passed to `sleep`), the command will now be executed correctly.