### PR TITLE
Small build updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build-release
+
+on:
+  push:
+    tags:
+    - v*
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.17' # The Go version to download (if necessary) and use.
+      - name: Test
+        run: go test
+      - name: Build
+        run: |
+          make
+      - name: Release
+        # softprops/action-gh-release v0.1.12
+        uses: softprops/action-gh-release@2d72d869af3bf23602f9593a1e3fd739b80ac1eb
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dinit
+          body: |
+            See the [CHANGELOG](https://github.com/lnxjedi/env-aws-params/blob/main/CHANGELOG.md)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Release
         # softprops/action-gh-release v0.1.12
         uses: softprops/action-gh-release@2d72d869af3bf23602f9593a1e3fd739b80ac1eb
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dinit
           body: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           files: dinit
           body: |
-            See the [CHANGELOG](https://github.com/lnxjedi/env-aws-params/blob/main/CHANGELOG.md)
+            See the [CHANGELOG](https://github.com/lnxjedi/dinit/blob/main/CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# v0.1.0
+
+First lnxjedi release.
+* Makefile/build updates, Go module config
+* Use GitHub Actions for build/release

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dinit
 
 dinit: env.go main.go process.go unix.go arg.go
-	CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo
+	CGO_ENABLED=0 go build -ldflags="-s -w" -a -tags netgo -installsuffix netgo
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dinit
 
 dinit: env.go main.go process.go unix.go arg.go
-	CGO_ENABLED=0 go build -ldflags="-s -w" -a -tags netgo -installsuffix netgo
+	CGO_ENABLED=0 go build -ldflags="-s -w" -a -tags netgo -installsuffix netgo -o dinit
 
 .PHONY: docker
 docker:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/lnxjedi/dinit
+
+go 1.17


### PR DESCRIPTION
* Make sure it always builds "dinit", regardless of the directory it's cloned to
* Strip the binary (smaller is better for containers)